### PR TITLE
Fix PathParams Cast Exeception in WebTestClient Module

### DIFF
--- a/modules/spring-web-test-client/src/main/java/io/restassured/module/webtestclient/internal/WebTestClientRequestSenderImpl.java
+++ b/modules/spring-web-test-client/src/main/java/io/restassured/module/webtestclient/internal/WebTestClientRequestSenderImpl.java
@@ -593,7 +593,7 @@ public class WebTestClientRequestSenderImpl implements WebTestClientRequestSende
 		do {
 			final String paramName = pathParamMatcher.group(1);
 			getPathParamValueFunction.apply(paramName).ifPresent(paramValue ->
-					uriVariables.put(paramName, UriUtils.encode((String) paramValue, Charsets.UTF_8))
+					uriVariables.put(paramName, paramValue)
 			);
 		} while (pathParamMatcher.find());
 


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Remove unnecessary URI encoding for path parameters

- Fix ClassCastException in WebTestClient module


___

### **Changes diagram**

```mermaid
flowchart LR
  A["Path Parameter"] --> B["Remove URI Encoding"] --> C["Direct Assignment"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>WebTestClientRequestSenderImpl.java</strong><dd><code>Remove URI encoding for path parameters</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

modules/spring-web-test-client/src/main/java/io/restassured/module/webtestclient/internal/WebTestClientRequestSenderImpl.java

<li>Remove <code>UriUtils.encode()</code> call for path parameters<br> <li> Eliminate string casting that caused ClassCastException<br> <li> Assign parameter values directly to URI variables


</details>


  </td>
  <td><a href="https://github.com/hantsy/rest-assured/pull/2/files#diff-fe27e709d68c9b4e6ffe17dd2f708cbcc8e81743acb1595b953c7474bdb028be">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>